### PR TITLE
Add Pi System Controls Obsidian plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.DS_Store
+
+# Build artifacts
+main.js.map

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# pi-system-controles
+# Pi System Controls
+
+Obsidian plugin for Raspberry Pi systems that provides battery status for Waveshare UPS HAT (E) and quick access to common controls such as Wi-Fi, Bluetooth, screen brightness and power management.
+
+## Features
+
+- Shows UPS battery percentage and estimated time in the status bar.
+- Updates battery information every 10 seconds via I²C at address `0x2D`.
+- System menu (⚙️) with toggles for Wi-Fi and Bluetooth, brightness slider, and reboot/power-off buttons.
+- All controls are accessible through Obsidian hotkeys.
+- Ensures screen brightness never falls below 10%.
+
+## Development
+
+```
+npm install
+npm run build
+```
+
+## Testing
+
+```
+npm test
+```
+
+> This plugin targets Linux environments and requires access to `rfkill`, `/sys/class/backlight`, and I²C bus 1. The `i2c-tools` package (providing `i2cget`) must be installed for battery readings. When installing manually, place the files in a folder named `pi-system-controls` to match the `id` in `manifest.json`.

--- a/main.js
+++ b/main.js
@@ -1,0 +1,255 @@
+import { Plugin, PluginSettingTab, Setting, Notice } from 'obsidian';
+import { exec } from 'child_process';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+const DEFAULT_SETTINGS = {
+    useSudo: false
+};
+export default class PiSystemControlsPlugin extends Plugin {
+    constructor() {
+        super(...arguments);
+        this.settings = DEFAULT_SETTINGS;
+        this.menuEl = null;
+        this.backlightPath = null;
+        this.handleDocClick = (evt) => {
+            if (this.menuEl && !this.menuEl.contains(evt.target) && !this.gearEl.contains(evt.target)) {
+                this.hideMenu();
+            }
+        };
+        this.handleKeyDown = (evt) => {
+            if (evt.key === 'Escape')
+                this.hideMenu();
+        };
+    }
+    async onload() {
+        await this.loadSettings();
+        this.statusEl = this.addStatusBarItem();
+        this.statusEl.setText('-- % (ukendt)');
+        this.gearEl = this.addStatusBarItem();
+        this.gearEl.setText('⚙️');
+        this.gearEl.addClass('pi-system-gear');
+        this.gearEl.addEventListener('click', () => this.toggleMenu());
+        this.buildMenu();
+        document.addEventListener('click', this.handleDocClick, true);
+        document.addEventListener('keydown', this.handleKeyDown, true);
+        this.interval = setInterval(() => this.refreshBattery(), 10000);
+        this.refreshBattery();
+        this.addCommand({ id: 'toggle-wifi', name: 'Toggle Wi-Fi', callback: () => this.toggleWifi() });
+        this.addCommand({ id: 'toggle-bluetooth', name: 'Toggle Bluetooth', callback: () => this.toggleBluetooth() });
+        this.addCommand({ id: 'brightness-up', name: 'Increase brightness', callback: () => this.adjustBrightness(10) });
+        this.addCommand({ id: 'brightness-down', name: 'Decrease brightness', callback: () => this.adjustBrightness(-10) });
+        this.addSettingTab(new PiSystemControlsSettingTab(this.app, this));
+    }
+    onunload() {
+        clearInterval(this.interval);
+        document.removeEventListener('click', this.handleDocClick, true);
+        document.removeEventListener('keydown', this.handleKeyDown, true);
+        this.menuEl?.remove();
+    }
+    async loadSettings() {
+        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    }
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
+    async refreshBattery() {
+        const info = await readBatteryInfo();
+        if (!info) {
+            this.statusEl.setText('-- % (ukendt)');
+            return;
+        }
+        const time = formatMinutes(info.minutes);
+        if (info.charging) {
+            this.statusEl.setText(`${info.percent} % (${time} til fuld opladning)`);
+        }
+        else {
+            this.statusEl.setText(`${info.percent} % (${time})`);
+        }
+    }
+    buildMenu() {
+        this.menuEl = createDiv({ cls: 'pi-system-menu hidden' });
+        document.body.appendChild(this.menuEl);
+        // Wi-Fi toggle
+        const wifiRow = this.menuEl.createDiv({ cls: 'pi-row' });
+        wifiRow.createSpan({ text: 'Wi-Fi' });
+        const wifiInput = wifiRow.createEl('input', { type: 'checkbox' });
+        wifiInput.onchange = async () => {
+            await this.setRfkill('wifi', wifiInput.checked);
+        };
+        getRfkillState('wifi').then(state => { if (state != null)
+            wifiInput.checked = state; });
+        // Bluetooth toggle
+        const btRow = this.menuEl.createDiv({ cls: 'pi-row' });
+        btRow.createSpan({ text: 'Bluetooth' });
+        const btInput = btRow.createEl('input', { type: 'checkbox' });
+        btInput.onchange = async () => {
+            await this.setRfkill('bluetooth', btInput.checked);
+        };
+        getRfkillState('bluetooth').then(state => { if (state != null)
+            btInput.checked = state; });
+        // Brightness slider
+        const brRow = this.menuEl.createDiv({ cls: 'pi-row' });
+        brRow.createSpan({ text: 'Lysstyrke' });
+        const brInput = brRow.createEl('input', { type: 'range' });
+        brInput.min = '10';
+        brInput.max = '100';
+        brInput.oninput = async () => {
+            const val = parseInt(brInput.value, 10);
+            await this.setBrightness(val);
+        };
+        getBrightness().then(v => { if (v != null)
+            brInput.value = v.toString(); });
+        // Reboot button
+        const rbRow = this.menuEl.createDiv({ cls: 'pi-row' });
+        const rbBtn = rbRow.createEl('button', { text: 'Genstart' });
+        rbBtn.onclick = () => this.runCmd('systemctl reboot');
+        // Shutdown button
+        const sdRow = this.menuEl.createDiv({ cls: 'pi-row' });
+        const sdBtn = sdRow.createEl('button', { text: 'Sluk' });
+        sdBtn.onclick = () => this.runCmd('systemctl poweroff');
+    }
+    toggleMenu() {
+        if (!this.menuEl)
+            return;
+        if (this.menuEl.hasClass('hidden')) {
+            this.menuEl.removeClass('hidden');
+        }
+        else {
+            this.menuEl.addClass('hidden');
+        }
+    }
+    hideMenu() { this.menuEl?.addClass('hidden'); }
+    async toggleWifi() {
+        const state = await getRfkillState('wifi');
+        if (state != null)
+            await this.setRfkill('wifi', !state);
+    }
+    async toggleBluetooth() {
+        const state = await getRfkillState('bluetooth');
+        if (state != null)
+            await this.setRfkill('bluetooth', !state);
+    }
+    async adjustBrightness(delta) {
+        const current = await getBrightness();
+        if (current == null)
+            return;
+        const next = Math.min(100, Math.max(10, current + delta));
+        await this.setBrightness(next);
+    }
+    async setBrightness(percent) {
+        if (!this.backlightPath) {
+            this.backlightPath = await findBacklight();
+            if (!this.backlightPath) {
+                new Notice('Ingen baggrundslys-enhed');
+                return;
+            }
+        }
+        const maxStr = await fs.readFile(path.join(this.backlightPath, 'max_brightness'), 'utf8');
+        const max = parseInt(maxStr.trim(), 10);
+        const min = Math.round(max * 0.1);
+        const value = Math.round((percent / 100) * (max - min) + min);
+        await fs.writeFile(path.join(this.backlightPath, 'brightness'), value.toString());
+    }
+    async setRfkill(target, on) {
+        const action = on ? 'unblock' : 'block';
+        await execAsync(`rfkill ${action} ${target}`);
+    }
+    runCmd(cmd) {
+        const full = this.settings.useSudo ? `sudo ${cmd}` : cmd;
+        exec(full);
+    }
+}
+class PiSystemControlsSettingTab extends PluginSettingTab {
+    constructor(app, plugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
+    display() {
+        const { containerEl } = this;
+        containerEl.empty();
+        new Setting(containerEl)
+            .setName('Use sudo for power commands')
+            .addToggle(t => t.setValue(this.plugin.settings.useSudo)
+            .onChange(async (value) => {
+            this.plugin.settings.useSudo = value;
+            await this.plugin.saveSettings();
+        }));
+    }
+}
+async function getRfkillState(target) {
+    try {
+        const out = await execAsync(`rfkill list ${target}`);
+        return !/Soft blocked: yes/.test(out);
+    }
+    catch (e) {
+        console.error(e);
+        return null;
+    }
+}
+async function execAsync(cmd) {
+    return new Promise((resolve, reject) => {
+        exec(cmd, (error, stdout) => {
+            if (error)
+                reject(error);
+            else
+                resolve(stdout);
+        });
+    });
+}
+async function readBatteryInfo() {
+    try {
+        const p = await readReg(0x0a);
+        const ch = await readReg(0x0b);
+        const lo = await readReg(0x0c);
+        const hi = await readReg(0x0d);
+        return {
+            percent: p,
+            charging: ch === 1,
+            minutes: lo | (hi << 8)
+        };
+    }
+    catch (e) {
+        console.error('i2c read failed', e);
+        return null;
+    }
+}
+async function readReg(reg) {
+    const out = await execAsync(`i2cget -y 1 0x2d 0x${reg.toString(16)}`);
+    return parseInt(out, 16);
+}
+function formatMinutes(mins) {
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    if (h > 0)
+        return `${h}t ${m}m`;
+    return `${m}m`;
+}
+async function findBacklight() {
+    try {
+        const entries = await fs.readdir('/sys/class/backlight');
+        if (entries.length === 0)
+            return null;
+        return path.join('/sys/class/backlight', entries[0]);
+    }
+    catch (e) {
+        console.error(e);
+        return null;
+    }
+}
+async function getBrightness() {
+    const backlight = await findBacklight();
+    if (!backlight)
+        return null;
+    try {
+        const maxStr = await fs.readFile(path.join(backlight, 'max_brightness'), 'utf8');
+        const curStr = await fs.readFile(path.join(backlight, 'brightness'), 'utf8');
+        const max = parseInt(maxStr.trim(), 10);
+        const cur = parseInt(curStr.trim(), 10);
+        const min = Math.round(max * 0.1);
+        return Math.round(((cur - min) / (max - min)) * 100);
+    }
+    catch (e) {
+        console.error(e);
+        return null;
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-system-controls",
+  "name": "Pi System Controls",
+  "version": "1.0.0",
+  "minAppVersion": "0.15.0",
+  "description": "System controls and Waveshare UPS HAT (E) battery status for Raspberry Pi",
+  "author": "OpenAI ChatGPT",
+  "authorUrl": "https://www.waveshare.com/",
+  "isDesktopOnly": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,158 @@
+{
+  "name": "pi-system-controls",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-system-controls",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "obsidian": "^1.5.8",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
+      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/obsidian": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+      "integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "pi-system-controls",
+  "version": "1.0.0",
+  "description": "Obsidian plugin providing Raspberry Pi system controls and UPS status",
+  "main": "main.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc -w",
+    "test": "tsc --noEmit"
+  },
+  "keywords": [
+    "obsidian",
+    "plugin",
+    "raspberry-pi"
+  ],
+  "author": "OpenAI ChatGPT",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "obsidian": "^1.5.8",
+    "typescript": "^5.9.2"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,287 @@
+import { App, Plugin, PluginSettingTab, Setting, Notice } from 'obsidian';
+import { exec } from 'child_process';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+interface PiSystemControlsSettings {
+useSudo: boolean;
+}
+
+const DEFAULT_SETTINGS: PiSystemControlsSettings = {
+useSudo: false
+};
+
+interface BatteryInfo {
+percent: number;
+charging: boolean;
+minutes: number;
+}
+
+export default class PiSystemControlsPlugin extends Plugin {
+settings: PiSystemControlsSettings = DEFAULT_SETTINGS;
+statusEl!: HTMLElement;
+gearEl!: HTMLElement;
+menuEl: HTMLElement | null = null;
+interval!: ReturnType<typeof setInterval>;
+backlightPath: string | null = null;
+
+async onload() {
+await this.loadSettings();
+
+this.statusEl = this.addStatusBarItem();
+this.statusEl.setText('-- % (ukendt)');
+
+this.gearEl = this.addStatusBarItem();
+this.gearEl.setText('⚙️');
+this.gearEl.addClass('pi-system-gear');
+this.gearEl.addEventListener('click', () => this.toggleMenu());
+
+this.buildMenu();
+
+document.addEventListener('click', this.handleDocClick, true);
+document.addEventListener('keydown', this.handleKeyDown, true);
+
+this.interval = setInterval(() => this.refreshBattery(), 10000);
+this.refreshBattery();
+
+this.addCommand({ id: 'toggle-wifi', name: 'Toggle Wi-Fi', callback: () => this.toggleWifi() });
+this.addCommand({ id: 'toggle-bluetooth', name: 'Toggle Bluetooth', callback: () => this.toggleBluetooth() });
+this.addCommand({ id: 'brightness-up', name: 'Increase brightness', callback: () => this.adjustBrightness(10) });
+this.addCommand({ id: 'brightness-down', name: 'Decrease brightness', callback: () => this.adjustBrightness(-10) });
+
+ this.addSettingTab(new PiSystemControlsSettingTab(this.app, this));
+}
+
+onunload() {
+clearInterval(this.interval);
+document.removeEventListener('click', this.handleDocClick, true);
+document.removeEventListener('keydown', this.handleKeyDown, true);
+this.menuEl?.remove();
+}
+
+async loadSettings() {
+this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+}
+
+async saveSettings() {
+await this.saveData(this.settings);
+}
+
+handleDocClick = (evt: MouseEvent) => {
+if (this.menuEl && !this.menuEl.contains(evt.target as Node) && !this.gearEl.contains(evt.target as Node)) {
+this.hideMenu();
+}
+};
+
+handleKeyDown = (evt: KeyboardEvent) => {
+if (evt.key === 'Escape') this.hideMenu();
+};
+
+async refreshBattery() {
+const info = await readBatteryInfo();
+if (!info) {
+this.statusEl.setText('-- % (ukendt)');
+return;
+}
+const time = formatMinutes(info.minutes);
+if (info.charging) {
+this.statusEl.setText(`${info.percent} % (${time} til fuld opladning)`);
+} else {
+this.statusEl.setText(`${info.percent} % (${time})`);
+}
+}
+
+buildMenu() {
+this.menuEl = createDiv({ cls: 'pi-system-menu hidden' });
+document.body.appendChild(this.menuEl);
+
+// Wi-Fi toggle
+const wifiRow = this.menuEl.createDiv({ cls: 'pi-row' });
+wifiRow.createSpan({ text: 'Wi-Fi' });
+const wifiInput = wifiRow.createEl('input', { type: 'checkbox' });
+wifiInput.onchange = async () => {
+await this.setRfkill('wifi', wifiInput.checked);
+};
+getRfkillState('wifi').then(state => { if (state != null) wifiInput.checked = state; });
+
+// Bluetooth toggle
+const btRow = this.menuEl.createDiv({ cls: 'pi-row' });
+btRow.createSpan({ text: 'Bluetooth' });
+const btInput = btRow.createEl('input', { type: 'checkbox' });
+btInput.onchange = async () => {
+await this.setRfkill('bluetooth', btInput.checked);
+};
+getRfkillState('bluetooth').then(state => { if (state != null) btInput.checked = state; });
+
+// Brightness slider
+const brRow = this.menuEl.createDiv({ cls: 'pi-row' });
+brRow.createSpan({ text: 'Lysstyrke' });
+const brInput = brRow.createEl('input', { type: 'range' });
+brInput.min = '10';
+brInput.max = '100';
+brInput.oninput = async () => {
+const val = parseInt(brInput.value, 10);
+await this.setBrightness(val);
+};
+getBrightness().then(v => { if (v != null) brInput.value = v.toString(); });
+
+// Reboot button
+const rbRow = this.menuEl.createDiv({ cls: 'pi-row' });
+const rbBtn = rbRow.createEl('button', { text: 'Genstart' });
+rbBtn.onclick = () => this.runCmd('systemctl reboot');
+
+// Shutdown button
+const sdRow = this.menuEl.createDiv({ cls: 'pi-row' });
+const sdBtn = sdRow.createEl('button', { text: 'Sluk' });
+sdBtn.onclick = () => this.runCmd('systemctl poweroff');
+}
+
+toggleMenu() {
+if (!this.menuEl) return;
+if (this.menuEl.hasClass('hidden')) {
+this.menuEl.removeClass('hidden');
+} else {
+this.menuEl.addClass('hidden');
+}
+}
+
+hideMenu() { this.menuEl?.addClass('hidden'); }
+
+async toggleWifi() {
+const state = await getRfkillState('wifi');
+if (state != null) await this.setRfkill('wifi', !state);
+}
+
+async toggleBluetooth() {
+const state = await getRfkillState('bluetooth');
+if (state != null) await this.setRfkill('bluetooth', !state);
+}
+
+async adjustBrightness(delta: number) {
+const current = await getBrightness();
+if (current == null) return;
+const next = Math.min(100, Math.max(10, current + delta));
+await this.setBrightness(next);
+}
+
+async setBrightness(percent: number) {
+if (!this.backlightPath) {
+this.backlightPath = await findBacklight();
+if (!this.backlightPath) {
+new Notice('Ingen baggrundslys-enhed');
+return;
+}
+}
+const maxStr = await fs.readFile(path.join(this.backlightPath, 'max_brightness'), 'utf8');
+const max = parseInt(maxStr.trim(), 10);
+const min = Math.round(max * 0.1);
+const value = Math.round((percent / 100) * (max - min) + min);
+await fs.writeFile(path.join(this.backlightPath, 'brightness'), value.toString());
+}
+
+async setRfkill(target: 'wifi' | 'bluetooth', on: boolean) {
+const action = on ? 'unblock' : 'block';
+await execAsync(`rfkill ${action} ${target}`);
+}
+
+runCmd(cmd: string) {
+const full = this.settings.useSudo ? `sudo ${cmd}` : cmd;
+exec(full);
+}
+}
+
+class PiSystemControlsSettingTab extends PluginSettingTab {
+plugin: PiSystemControlsPlugin;
+
+constructor(app: App, plugin: PiSystemControlsPlugin) {
+super(app, plugin);
+this.plugin = plugin;
+}
+
+display(): void {
+const { containerEl } = this;
+containerEl.empty();
+new Setting(containerEl)
+.setName('Use sudo for power commands')
+.addToggle(t => t.setValue(this.plugin.settings.useSudo)
+.onChange(async (value) => {
+this.plugin.settings.useSudo = value;
+await this.plugin.saveSettings();
+}));
+}
+}
+
+async function getRfkillState(target: 'wifi' | 'bluetooth'): Promise<boolean | null> {
+try {
+const out = await execAsync(`rfkill list ${target}`);
+return !/Soft blocked: yes/.test(out);
+} catch (e) {
+console.error(e);
+return null;
+}
+}
+
+async function execAsync(cmd: string): Promise<string> {
+return new Promise((resolve, reject) => {
+exec(cmd, (error, stdout) => {
+if (error) reject(error);
+else resolve(stdout);
+});
+});
+}
+
+async function readBatteryInfo(): Promise<BatteryInfo | null> {
+  try {
+    const p = await readReg(0x0a);
+    const ch = await readReg(0x0b);
+    const lo = await readReg(0x0c);
+    const hi = await readReg(0x0d);
+    return {
+      percent: p,
+      charging: ch === 1,
+      minutes: lo | (hi << 8)
+    };
+  } catch (e) {
+    console.error('i2c read failed', e);
+    return null;
+  }
+}
+
+async function readReg(reg: number): Promise<number> {
+  const out = await execAsync(`i2cget -y 1 0x2d 0x${reg.toString(16)}`);
+  return parseInt(out, 16);
+}
+
+function formatMinutes(mins: number): string {
+const h = Math.floor(mins / 60);
+const m = mins % 60;
+if (h > 0) return `${h}t ${m}m`;
+return `${m}m`;
+}
+
+async function findBacklight(): Promise<string | null> {
+try {
+const entries = await fs.readdir('/sys/class/backlight');
+if (entries.length === 0) return null;
+return path.join('/sys/class/backlight', entries[0]);
+} catch (e) {
+console.error(e);
+return null;
+}
+}
+
+async function getBrightness(): Promise<number | null> {
+const backlight = await findBacklight();
+if (!backlight) return null;
+try {
+const maxStr = await fs.readFile(path.join(backlight, 'max_brightness'), 'utf8');
+const curStr = await fs.readFile(path.join(backlight, 'brightness'), 'utf8');
+const max = parseInt(maxStr.trim(), 10);
+const cur = parseInt(curStr.trim(), 10);
+const min = Math.round(max * 0.1);
+return Math.round(((cur - min) / (max - min)) * 100);
+} catch (e) {
+console.error(e);
+return null;
+}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM"],
+    "outDir": ".",
+    "types": ["node", "obsidian"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Pi System Controls plugin showing UPS battery and exposing system toggles
- support Wi-Fi/Bluetooth switches, brightness slider with 10% minimum, and reboot/poweroff actions
- avoid native i2c-bus dependency by using `i2cget`; document `i2c-tools` requirement

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3dfd924483288bd9632814dd2094