### PR TITLE
Gracefully handle missing i2c-bus dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Obsidian plugin for Raspberry Pi systems that provides battery status for Wavesh
 - All controls are accessible through Obsidian hotkeys.
 - Ensures screen brightness never falls below 10%.
 
+> Battery status requires the `i2c-bus` module. If it isn't available, the plugin will still load but battery information will remain unknown.
+
 ## Development
 
 ```

--- a/main.js
+++ b/main.js
@@ -32,15 +32,11 @@ var __importStar = (this && this.__importStar) || (function () {
         return result;
     };
 })();
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const obsidian_1 = require("obsidian");
 const child_process_1 = require("child_process");
 const fs_1 = require("fs");
 const path = __importStar(require("path"));
-const i2c_bus_1 = __importDefault(require("i2c-bus"));
 const DEFAULT_SETTINGS = {
     useSudo: false
 };
@@ -237,8 +233,16 @@ async function execAsync(cmd) {
     });
 }
 async function readBatteryInfo() {
+    let i2c;
     try {
-        const bus = await i2c_bus_1.default.openPromisified(1);
+        i2c = require('i2c-bus');
+    }
+    catch (e) {
+        console.error('i2c-bus module not found', e);
+        return null;
+    }
+    try {
+        const bus = await i2c.openPromisified(1);
         const buf = Buffer.alloc(4);
         await bus.readI2cBlock(0x2d, 0x0a, 4, buf);
         await bus.close();


### PR DESCRIPTION
## Summary
- Avoid plugin crash when `i2c-bus` is absent by requiring it lazily and returning null if unavailable
- Document that UPS battery status needs the optional `i2c-bus` module

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4a0b220083288dad2ef766bba189