### PR TITLE
Use i2cget for battery readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Obsidian plugin for Raspberry Pi systems that provides battery status for Wavesh
 - All controls are accessible through Obsidian hotkeys.
 - Ensures screen brightness never falls below 10%.
 
-> Battery status requires the `i2c-bus` module. If it isn't available, the plugin will still load but battery information will remain unknown.
+> Battery status requires the `i2cget` command from the `i2c-tools` package. If it isn't available, the plugin will still load but battery information will remain unknown.
+> Install `i2c-tools` on your system to enable battery readings.
 
 ## Development
 

--- a/main.js
+++ b/main.js
@@ -233,27 +233,18 @@ async function execAsync(cmd) {
     });
 }
 async function readBatteryInfo() {
-    let i2c;
     try {
-        i2c = require('i2c-bus');
+        const percentHex = await execAsync('i2cget -y 1 0x2d 0x0a');
+        const chargingHex = await execAsync('i2cget -y 1 0x2d 0x0b');
+        const minsLoHex = await execAsync('i2cget -y 1 0x2d 0x0c');
+        const minsHiHex = await execAsync('i2cget -y 1 0x2d 0x0d');
+        const percent = parseInt(percentHex, 16);
+        const charging = parseInt(chargingHex, 16) === 1;
+        const minutes = parseInt(minsLoHex, 16) | (parseInt(minsHiHex, 16) << 8);
+        return { percent, charging, minutes };
     }
     catch (e) {
-        console.error('i2c-bus module not found', e);
-        return null;
-    }
-    try {
-        const bus = await i2c.openPromisified(1);
-        const buf = Buffer.alloc(4);
-        await bus.readI2cBlock(0x2d, 0x0a, 4, buf);
-        await bus.close();
-        return {
-            percent: buf[0],
-            charging: buf[1] === 1,
-            minutes: buf[2] | (buf[3] << 8)
-        };
-    }
-    catch (e) {
-        console.error('i2c read failed', e);
+        console.error('i2cget failed', e);
         return null;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,7 @@
       "name": "pi-system-controls",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "i2c-bus": "^5.2.2"
-      },
       "devDependencies": {
-        "@types/i2c-bus": "^5.1.1",
         "@types/node": "^20.11.30",
         "obsidian": "^1.5.8",
         "typescript": "^5.9.2"
@@ -68,16 +64,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/i2c-bus": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/i2c-bus/-/i2c-bus-5.1.2.tgz",
-      "integrity": "sha512-Zph1a3TZnvU8yUEhR8Yvv+Fv61dE3WQ2gMs4B2KgBUuKYE73quagMvmUN9EvRIbf4B+zq1WKMYjLOafdNus1ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
@@ -98,15 +84,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -114,26 +91,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
-    "node_modules/i2c-bus": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/i2c-bus/-/i2c-bus-5.2.3.tgz",
-      "integrity": "sha512-kzFgU0OSIZlaeUUa+VK7L+kkxnj4feimCVQDOPrzj0cTaB+hNweTsO8/j7QvW2gRgWQ7ds5IpfFjpBrX+fMNng==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.17.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/moment": {
       "version": "2.29.4",
@@ -144,12 +101,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "license": "MIT"
     },
     "node_modules/obsidian": {
       "version": "1.8.7",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
   ],
   "author": "OpenAI ChatGPT",
   "license": "MIT",
-  "dependencies": {
-    "i2c-bus": "^5.2.2"
-  },
   "devDependencies": {
-    "@types/i2c-bus": "^5.1.1",
     "@types/node": "^20.11.30",
     "obsidian": "^1.5.8",
     "typescript": "^5.9.2"


### PR DESCRIPTION
## Summary
- switch battery polling from the Node `i2c-bus` module to the `i2cget` command
- drop `i2c-bus` dependency and mention `i2c-tools` in the documentation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa4ee349308328b4256e1686367c2b