### PR TITLE
Fix UPS HAT battery readings and enable system menu toggle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -232,14 +232,27 @@ else resolve(stdout);
 
 async function readBatteryInfo(): Promise<BatteryInfo | null> {
     try {
-        const percentHex = await execAsync('i2cget -y 1 0x2d 0x0a');
-        const chargingHex = await execAsync('i2cget -y 1 0x2d 0x0b');
-        const minsLoHex = await execAsync('i2cget -y 1 0x2d 0x0c');
-        const minsHiHex = await execAsync('i2cget -y 1 0x2d 0x0d');
+        const [curLoHex, curHiHex, pctLoHex, pctHiHex, rteLoHex, rteHiHex, rtfLoHex, rtfHiHex] = await Promise.all([
+            execAsync('i2cget -y 1 0x2d 0x22'),
+            execAsync('i2cget -y 1 0x2d 0x23'),
+            execAsync('i2cget -y 1 0x2d 0x24'),
+            execAsync('i2cget -y 1 0x2d 0x25'),
+            execAsync('i2cget -y 1 0x2d 0x28'),
+            execAsync('i2cget -y 1 0x2d 0x29'),
+            execAsync('i2cget -y 1 0x2d 0x2a'),
+            execAsync('i2cget -y 1 0x2d 0x2b'),
+        ]);
 
-        const percent = parseInt(percentHex, 16);
-        const charging = parseInt(chargingHex, 16) === 1;
-        const minutes = parseInt(minsLoHex, 16) | (parseInt(minsHiHex, 16) << 8);
+        const toInt = (hex: string) => parseInt(hex, 16);
+
+        const currentRaw = toInt(curLoHex) | (toInt(curHiHex) << 8);
+        const current = currentRaw > 0x7fff ? currentRaw - 0x10000 : currentRaw;
+        const charging = current > 0;
+
+        const percent = toInt(pctLoHex) | (toInt(pctHiHex) << 8);
+        const timeToEmpty = toInt(rteLoHex) | (toInt(rteHiHex) << 8);
+        const timeToFull = toInt(rtfLoHex) | (toInt(rtfHiHex) << 8);
+        const minutes = charging ? timeToFull : timeToEmpty;
 
         return { percent, charging, minutes };
     } catch (e) {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,29 @@
+.pi-system-menu {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  background-color: var(--background-secondary);
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  z-index: 10000;
+}
+
+.pi-system-menu.hidden {
+  display: none;
+}
+
+.pi-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5em;
+}
+
+.pi-row:last-child {
+  margin-bottom: 0;
+}
+
+.pi-system-gear {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Correctly read battery percentage, current, and runtime from Waveshare UPS HAT (E)
- Add CSS styling so the gear icon toggles a visible system menu

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa5dad4d9483288c34ef56daff05c2