### PR TITLE
Use Obsidian-style toggles and icon power buttons

### DIFF
--- a/main.js
+++ b/main.js
@@ -107,21 +107,21 @@ class PiSystemControlsPlugin extends obsidian_1.Plugin {
         // Wi-Fi toggle
         const wifiRow = this.menuEl.createDiv({ cls: 'pi-row' });
         wifiRow.createSpan({ text: 'Wi-Fi' });
-        const wifiInput = wifiRow.createEl('input', { type: 'checkbox' });
-        wifiInput.onchange = async () => {
-            await this.setRfkill('wifi', wifiInput.checked);
-        };
+        const wifiToggle = new obsidian_1.ToggleComponent(wifiRow);
+        wifiToggle.onChange(async (value) => {
+            await this.setRfkill('wifi', value);
+        });
         getRfkillState('wifi').then(state => { if (state != null)
-            wifiInput.checked = state; });
+            wifiToggle.setValue(state); });
         // Bluetooth toggle
         const btRow = this.menuEl.createDiv({ cls: 'pi-row' });
         btRow.createSpan({ text: 'Bluetooth' });
-        const btInput = btRow.createEl('input', { type: 'checkbox' });
-        btInput.onchange = async () => {
-            await this.setRfkill('bluetooth', btInput.checked);
-        };
+        const btToggle = new obsidian_1.ToggleComponent(btRow);
+        btToggle.onChange(async (value) => {
+            await this.setRfkill('bluetooth', value);
+        });
         getRfkillState('bluetooth').then(state => { if (state != null)
-            btInput.checked = state; });
+            btToggle.setValue(state); });
         // Brightness slider
         const brRow = this.menuEl.createDiv({ cls: 'pi-row' });
         brRow.createSpan({ text: 'Lysstyrke' });
@@ -136,11 +136,13 @@ class PiSystemControlsPlugin extends obsidian_1.Plugin {
             brInput.value = v.toString(); });
         // Reboot button
         const rbRow = this.menuEl.createDiv({ cls: 'pi-row' });
-        const rbBtn = rbRow.createEl('button', { text: 'Genstart' });
+        const rbBtn = rbRow.createEl('button', { text: '↻' });
+        rbBtn.setAttribute('aria-label', 'Genstart');
         rbBtn.onclick = () => this.runCmd('systemctl reboot');
         // Shutdown button
         const sdRow = this.menuEl.createDiv({ cls: 'pi-row' });
-        const sdBtn = sdRow.createEl('button', { text: 'Sluk' });
+        const sdBtn = sdRow.createEl('button', { text: '⏻' });
+        sdBtn.setAttribute('aria-label', 'Sluk');
         sdBtn.onclick = () => this.runCmd('systemctl poweroff');
     }
     toggleMenu() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, PluginSettingTab, Setting, Notice } from 'obsidian';
+import { App, Plugin, PluginSettingTab, Setting, Notice, ToggleComponent } from 'obsidian';
 import { exec } from 'child_process';
 import { promises as fs } from 'fs';
 import * as path from 'path';
@@ -95,23 +95,23 @@ buildMenu() {
 this.menuEl = createDiv({ cls: 'pi-system-menu hidden' });
 document.body.appendChild(this.menuEl);
 
-// Wi-Fi toggle
-const wifiRow = this.menuEl.createDiv({ cls: 'pi-row' });
-wifiRow.createSpan({ text: 'Wi-Fi' });
-const wifiInput = wifiRow.createEl('input', { type: 'checkbox' });
-wifiInput.onchange = async () => {
-await this.setRfkill('wifi', wifiInput.checked);
-};
-getRfkillState('wifi').then(state => { if (state != null) wifiInput.checked = state; });
+    // Wi-Fi toggle
+    const wifiRow = this.menuEl.createDiv({ cls: 'pi-row' });
+    wifiRow.createSpan({ text: 'Wi-Fi' });
+    const wifiToggle = new ToggleComponent(wifiRow);
+    wifiToggle.onChange(async (value) => {
+      await this.setRfkill('wifi', value);
+    });
+    getRfkillState('wifi').then(state => { if (state != null) wifiToggle.setValue(state); });
 
-// Bluetooth toggle
-const btRow = this.menuEl.createDiv({ cls: 'pi-row' });
-btRow.createSpan({ text: 'Bluetooth' });
-const btInput = btRow.createEl('input', { type: 'checkbox' });
-btInput.onchange = async () => {
-await this.setRfkill('bluetooth', btInput.checked);
-};
-getRfkillState('bluetooth').then(state => { if (state != null) btInput.checked = state; });
+    // Bluetooth toggle
+    const btRow = this.menuEl.createDiv({ cls: 'pi-row' });
+    btRow.createSpan({ text: 'Bluetooth' });
+    const btToggle = new ToggleComponent(btRow);
+    btToggle.onChange(async (value) => {
+      await this.setRfkill('bluetooth', value);
+    });
+    getRfkillState('bluetooth').then(state => { if (state != null) btToggle.setValue(state); });
 
 // Brightness slider
 const brRow = this.menuEl.createDiv({ cls: 'pi-row' });
@@ -125,15 +125,17 @@ await this.setBrightness(val);
 };
 getBrightness().then(v => { if (v != null) brInput.value = v.toString(); });
 
-// Reboot button
-const rbRow = this.menuEl.createDiv({ cls: 'pi-row' });
-const rbBtn = rbRow.createEl('button', { text: 'Genstart' });
-rbBtn.onclick = () => this.runCmd('systemctl reboot');
+    // Reboot button
+    const rbRow = this.menuEl.createDiv({ cls: 'pi-row' });
+    const rbBtn = rbRow.createEl('button', { text: '↻' });
+    rbBtn.setAttribute('aria-label', 'Genstart');
+    rbBtn.onclick = () => this.runCmd('systemctl reboot');
 
-// Shutdown button
-const sdRow = this.menuEl.createDiv({ cls: 'pi-row' });
-const sdBtn = sdRow.createEl('button', { text: 'Sluk' });
-sdBtn.onclick = () => this.runCmd('systemctl poweroff');
+    // Shutdown button
+    const sdRow = this.menuEl.createDiv({ cls: 'pi-row' });
+    const sdBtn = sdRow.createEl('button', { text: '⏻' });
+    sdBtn.setAttribute('aria-label', 'Sluk');
+    sdBtn.onclick = () => this.runCmd('systemctl poweroff');
 }
 
 toggleMenu() {


### PR DESCRIPTION
## Summary
- Replace checkbox inputs with Obsidian `ToggleComponent` for Wi‑Fi and Bluetooth.
- Show restart and shutdown buttons as icons only (↻ and ⏻) with accessible labels.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa6132526083289d06be15b1f9b16a